### PR TITLE
feat(rabbitmq): прокинуть heartbeat и параметры подключения через config

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ composer require chocofamilyme/pubsub
             'port'     => env('EVENTSOURCE_PORT', '5672'),
             'user'     => env('EVENTSOURCE_USER', 'guest'),
             'password' => env('EVENTSOURCE_PASSWORD', 'guest'),
+
+            // Опциональные параметры подключения (since 2.3.0)
+            'vhost'              => '/',
+            'heartbeat'          => 60,    // секунды; 0 = отключён (default)
+            'read_write_timeout' => 130,   // должен быть >= 2 * heartbeat
+            'connection_timeout' => 3,
+            'keepalive'          => true,  // включает SO_KEEPALIVE на сокете
         ],
     ],
 ]

--- a/src/PubSub/Provider/RabbitMQ.php
+++ b/src/PubSub/Provider/RabbitMQ.php
@@ -74,7 +74,17 @@ class RabbitMQ extends AbstractProvider
                 $this->config['host'],
                 $this->config['port'],
                 $this->config['user'],
-                $this->config['password']
+                $this->config['password'],
+                $this->config['vhost']               ?? '/',
+                false,
+                'AMQPLAIN',
+                null,
+                'en_US',
+                (float) ($this->config['connection_timeout'] ?? 3.0),
+                (float) ($this->config['read_write_timeout'] ?? 3.0),
+                null,
+                (bool)  ($this->config['keepalive']          ?? false),
+                (int)   ($this->config['heartbeat']          ?? 0)
             );
         } catch (\Exception $e) {
             throw new ConnectionException($e->getMessage(), $e->getCode(), $e);


### PR DESCRIPTION
## Проблема

`RabbitMQ::connect()` создаёт `AMQPStreamConnection` всего из 4 аргументов —
без heartbeat и keepalive. RMQ не отстреливает мёртвые сессии, и в сервисах
копятся «фантомные» консьюмеры (особенно заметно после переезда на новую
инфру с длинными conntrack/SNAT-таймаутами).

## Что меняется

В `connect()` пробрасываются опциональные ключи конфига с безопасными
дефолтами (поведение существующих потребителей не меняется):

- `vhost` (default `/`)
- `connection_timeout` (default `3.0`)
- `read_write_timeout` (default `3.0`)
- `keepalive` (default `false`)
- `heartbeat` (default `0`)

README обновлён.

## BC

Полностью обратносовместимо: API и composer-зависимости не трогаются.
Чтобы включить heartbeat — потребитель явно задаёт `heartbeat: 60` в config.

## Что нужно сделать мейнтейнеру (всё в веб-UI, ~1 минута)

`master` уже на 4.0.0 — мерджить туда нельзя. Нужна ветка `2.x`:

1. Зайти в репу → branch dropdown (вверху списка файлов) → ввести `2.x` →
   **Create branch: `2.x` from `2.2.1`**.
2. В этом PR → Edit (справа от title) → Base branch → выбрать `2.x` →
   Save.
3. Нажать **Merge pull request**.
4. Releases → **Draft a new release** → Tag `2.3.0`, Target `2.x` →
   Publish release.

После этого сервисы с констрейнтом `"chocofamilyme/pubsub": "^2"` через
`composer update` подтянут 2.3.0 и смогут включить heartbeat в config.
